### PR TITLE
Use `uv` to install Python requirements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,8 @@ FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends graphviz postgresql-client curl
+    apt-get install -y --no-install-recommends graphviz postgresql-client curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,4 +9,4 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 COPY codespace_requirements.txt /
 
-RUN uv pip install --system -r codespace_requirements.txt
+RUN /root/.cargo/bin/uv pip install --system -r codespace_requirements.txt

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
 FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
 
-COPY codespace_requirements.txt /
-
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends graphviz postgresql-client
+    apt-get install -y --no-install-recommends graphviz postgresql-client curl
 
-RUN python3 -m pip install -r codespace_requirements.txt
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+COPY codespace_requirements.txt /
+
+RUN uv pip install --system -r codespace_requirements.txt


### PR DESCRIPTION
Life is too short to wait for `pip install`