### PR TITLE
Upgrade Ibis (and remove patch) and recompile reqs

### DIFF
--- a/01 - Getting Started with Ibis.ipynb
+++ b/01 - Getting Started with Ibis.ipynb
@@ -1097,7 +1097,20 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "The Ibis `join` syntax is quite expressive, so we won't cover all the variations now; for more examples, read the [docs](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.join)."
+        "The Ibis `join` syntax is quite expressive, so we won't cover all the variations now; for more examples, read the [docs](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.join).\n",
+        "\n",
+        "Before we move on, let's terminate the DuckDB connection for good measure. If you skip this step, you may run into an error later on in the tutorial:\n",
+        "\n",
+        "    IO Error: Could not set lock on file \"/workspaces/kedro-ibis-tutorial/nycflights13.ddb\": Conflicting lock is held in /usr/local/bin/python3.11 (PID 1234). However, you would be able to open this database in read-only mode, e.g. by using the -readonly parameter in the CLI. See also https://duckdb.org/docs/connect/concurrency"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "con.disconnect()"
       ]
     }
   ],

--- a/codespace_requirements.txt
+++ b/codespace_requirements.txt
@@ -6,8 +6,6 @@ aiohttp==3.9.5
     # via gcsfs
 aiosignal==1.3.1
     # via aiohttp
-altair==5.3.0
-    # via -r requirements.txt
 annotated-types==0.7.0
     # via pydantic
 antlr4-python3-runtime==4.9.3
@@ -23,8 +21,6 @@ appdirs==1.4.4
     # via
     #   kedro-telemetry
     #   pins
-appnope==0.1.4
-    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -83,12 +79,8 @@ click-default-group==1.2.4
     # via kedro-viz
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
-    # via matplotlib
 cookiecutter==2.6.0
     # via kedro
-cycler==0.12.1
-    # via matplotlib
 debugpy==1.8.1
     # via ipykernel
 decorator==5.1.1
@@ -99,7 +91,7 @@ defusedxml==0.7.1
     # via nbconvert
 dnspython==2.6.1
     # via email-validator
-duckdb==0.10.2
+duckdb==1.0.0
     # via ibis-framework
 dynaconf==3.2.5
     # via kedro
@@ -113,8 +105,6 @@ fastapi-cli==0.0.4
     # via fastapi
 fastjsonschema==2.19.1
     # via nbformat
-fonttools==4.51.0
-    # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 frozenlist==1.4.1
@@ -161,6 +151,8 @@ googleapis-common-protos==1.63.0
     # via google-api-core
 graphql-core==3.2.3
     # via strawberry-graphql
+greenlet==3.0.3
+    # via sqlalchemy
 h11==0.14.0
     # via
     #   httpcore
@@ -175,7 +167,7 @@ httpx==0.27.0
     #   jupyterlab
 humanize==4.9.0
     # via pins
-ibis-framework==9.0.0
+ibis-framework==9.1.0
     # via
     #   -r demo/delay-prediction/requirements.txt
     #   ibis-ml
@@ -210,7 +202,6 @@ jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
-    #   altair
     #   cookiecutter
     #   fastapi
     #   jupyter-server
@@ -228,7 +219,6 @@ jsonpointer==2.4
     # via jsonschema
 jsonschema==4.22.0
     # via
-    #   altair
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
@@ -278,8 +268,6 @@ kedro-telemetry==0.4.0
     # via -r demo/delay-prediction/requirements.txt
 kedro-viz==9.1.0
     # via -r demo/delay-prediction/requirements.txt
-kiwisolver==1.4.5
-    # via matplotlib
 lazy-loader==0.4
     # via kedro-datasets
 markdown-it-py==3.0.0
@@ -288,8 +276,6 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.8.4
-    # via plotnine
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -298,8 +284,6 @@ mdurl==0.1.2
     # via markdown-it-py
 mistune==3.0.2
     # via nbconvert
-mizani==0.11.2
-    # via plotnine
 more-itertools==10.2.0
     # via kedro
 multidict==6.0.5
@@ -323,18 +307,11 @@ notebook-shim==0.2.4
     # via jupyterlab
 numpy==1.26.4
     # via
-    #   altair
-    #   contourpy
     #   ibis-framework
-    #   matplotlib
-    #   mizani
     #   pandas
-    #   patsy
-    #   plotnine
     #   pyarrow
     #   scikit-learn
     #   scipy
-    #   statsmodels
 oauthlib==3.2.2
     # via requests-oauthlib
 omegaconf==2.3.0
@@ -347,7 +324,6 @@ overrides==7.7.0
     # via jupyter-server
 packaging==23.2
     # via
-    #   altair
     #   build
     #   ibis-framework
     #   ipykernel
@@ -356,20 +332,14 @@ packaging==23.2
     #   jupyterlab-server
     #   kedro-viz
     #   lazy-loader
-    #   matplotlib
     #   nbconvert
     #   plotly
     #   pytoolconfig
-    #   statsmodels
 pandas==2.2.2
     # via
-    #   altair
     #   ibis-framework
     #   kedro-viz
-    #   mizani
     #   pins
-    #   plotnine
-    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parse==1.20.1
@@ -378,12 +348,8 @@ parso==0.8.4
     # via jedi
 parsy==2.1
     # via ibis-framework
-patsy==0.5.6
-    # via statsmodels
 pexpect==4.9.0
     # via ipython
-pillow==10.3.0
-    # via matplotlib
 pins==0.8.6
     # via ibis-framework
 platformdirs==4.2.1
@@ -391,11 +357,7 @@ platformdirs==4.2.1
     #   jupyter-core
     #   pytoolconfig
 plotly==5.22.0
-    # via
-    #   -r requirements.txt
-    #   kedro-viz
-plotnine==0.13.5
-    # via -r requirements.txt
+    # via kedro-viz
 pluggy==1.5.0
     # via kedro
 polars==0.20.23
@@ -446,8 +408,6 @@ pygments==2.18.0
     #   ipython
     #   nbconvert
     #   rich
-pyparsing==3.1.2
-    # via matplotlib
 pyproject-hooks==1.1.0
     # via build
 python-dateutil==2.9.0.post0
@@ -455,7 +415,6 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   ibis-framework
     #   jupyter-client
-    #   matplotlib
     #   pandas
     #   strawberry-graphql
 python-dotenv==1.0.1
@@ -531,11 +490,7 @@ ruamel-yaml-clib==0.2.8
 scikit-learn==1.5.0
     # via -r demo/delay-prediction/requirements.txt
 scipy==1.13.0
-    # via
-    #   mizani
-    #   plotnine
-    #   scikit-learn
-    #   statsmodels
+    # via scikit-learn
 secure==0.3.0
     # via kedro-viz
 send2trash==1.8.3
@@ -546,7 +501,6 @@ six==1.16.0
     # via
     #   asttokens
     #   bleach
-    #   patsy
     #   python-dateutil
     #   rfc3339-validator
 smmap==5.0.1
@@ -565,8 +519,6 @@ stack-data==0.6.3
     # via ipython
 starlette==0.37.2
     # via fastapi
-statsmodels==0.14.2
-    # via plotnine
 strawberry-graphql==0.234.2
     # via kedro-viz
 tenacity==8.2.3
@@ -584,9 +536,7 @@ tinycss2==1.3.0
 toml==0.10.2
     # via kedro
 toolz==0.12.1
-    # via
-    #   altair
-    #   ibis-framework
+    # via ibis-framework
 toposort==1.10
     # via kedro-viz
 tornado==6.4

--- a/demo/delay-prediction/requirements.txt
+++ b/demo/delay-prediction/requirements.txt
@@ -1,4 +1,4 @@
-ibis-framework[duckdb,polars,examples]==9.0.0
+ibis-framework[duckdb,polars,examples]~=9.1
 ibis-ml
 kedro~=0.19.6
 kedro-datasets[ibis-duckdb,ibis-postgres]~=3.0.1

--- a/demo/delay-prediction/src/delay_prediction/__init__.py
+++ b/demo/delay-prediction/src/delay_prediction/__init__.py
@@ -2,36 +2,3 @@
 """
 
 __version__ = "0.1"
-
-
-def _auto_patch_ibis() -> None:
-    import ibis.backends.postgres.compiler
-    import ibis.common.exceptions as com
-
-    def visit_Hash(self, op, *, arg):
-        arg_dtype = op.arg.dtype
-
-        if arg_dtype.is_int16():
-            return self.f.hashint2extended(arg, 0)
-        elif arg_dtype.is_int32():
-            return self.f.hashint4extended(arg, 0)
-        elif arg_dtype.is_int64():
-            return self.f.hashint8extended(arg, 0)
-        elif arg_dtype.is_float32():
-            return self.f.hashfloat4extended(arg, 0)
-        elif arg_dtype.is_float64():
-            return self.f.hashfloat8extended(arg, 0)
-        elif arg_dtype.is_string():
-            return self.f.hashtextextended(arg, 0)
-        elif arg_dtype.is_macaddr():
-            return self.f.hashmacaddr8extended(arg, 0)
-
-        raise com.UnsupportedOperationError(
-            f"Hash({arg_dtype!r}) operation is not supported in the "
-            f"{self.dialect} backend"
-        )
-
-    ibis.backends.postgres.compiler.PostgresCompiler.visit_Hash = visit_Hash
-
-
-_auto_patch_ibis()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 -r demo/delay-prediction/requirements.txt
 
-altair==5.3.0
 jupyterlab==4.1.8
-plotnine==0.13.5
-plotly>=5.22.0


### PR DESCRIPTION
* Upgrade to Ibis 9.1.0, and remove the relevant auto-patch in the Kedro project
* Disconnect the DuckDB session at the end of `01 - Getting Started with Ibis.ipynb`
* Recompile the requirements using `uv`, after cleaning the cache, to get latest dependencies like DuckDB 1.0